### PR TITLE
ajustement TimeInterval en fonction de la latence

### DIFF
--- a/DiscordHealBot/DiscordHealBot/Startup.cs
+++ b/DiscordHealBot/DiscordHealBot/Startup.cs
@@ -47,17 +47,19 @@ namespace DiscordHealBot
             {
                 Logger.LogInformation("Job is looping");
 
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
                 List<EndPointHealthResult> epResults = await RunEndPointsAsync();
                 await BroadCaster.BroadcastResultsAsync(epResults, this.DiscordWebHook, Settings.FamilyReporting);
-                await Task.Delay(Settings.GetTimeIntervalInMs());
+                stopwatch.Stop();
+
+                int result = Settings.GetTimeIntervalInMs() > (int)(stopwatch.ElapsedMilliseconds)
+                    ? Settings.GetTimeIntervalInMs() - (int)(stopwatch.ElapsedMilliseconds)
+                    : Settings.GetTimeIntervalInMs();
+
+                await Task.Delay(result);
             }
         }
-
-      
-
-   
-
-   
 
         private async Task<List<EndPointHealthResult>> RunEndPointsAsync()
         {


### PR DESCRIPTION
Hello, 

Nous te proposons une petite amélioration pour ajuster l'intervalle d'exécution du bot en fonction de la latence des différents endpoints cibles. Jusqu'à présent, nous avions constaté un décalage d'environ 1 minute par jour (en ce basant sur un TimeInterval à 3600s) dû à la latence de réponse de nos endpoints.

Pour toutes informations complémentaires, nous restons à ta disposition dans le canal #général ;)