### PR TITLE
improvement LatencyBot : storage and fixed time broadcast

### DIFF
--- a/DiscordHealBot/DiscordHealBot/BroadCaster.cs
+++ b/DiscordHealBot/DiscordHealBot/BroadCaster.cs
@@ -26,6 +26,21 @@ namespace DiscordHealBot
             await client.SendMessageAsync(embeds: embeds, username: "Latency Bot");
         }
 
+        public static async Task BroadcastAlertAsync(List<EndPointHealthResult> epResults, string discordWebhook)
+        {
+            var client = new DiscordWebhookClient(discordWebhook);
+            Color embedColor = Color.Red;
+            EmbedBuilder builder = new EmbedBuilder();
+            var description = epResults.Select(x =>
+            {
+                return $"⚠ : {x.EndpointAddress} responds with code {x.StatusCode} in {x.Latency}ms @here";
+            }).ToList();
+            var b = builder.WithTitle("Latency Alert")
+                .WithDescription(string.Join('\n', description))
+                .WithColor(embedColor)
+                .Build();
+        }
+
         private static Color DecideEmbedColorClassic(List<EndPointHealthResult> epResults)
         {
             if (epResults.Any(x => !x.Success) || epResults.Any(x => x.Latency > 10000))

--- a/DiscordHealBot/DiscordHealBot/DiscordHealBot.csproj
+++ b/DiscordHealBot/DiscordHealBot/DiscordHealBot.csproj
@@ -14,7 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="appsettings.json" />
       <Content Include="appsettings.json" Condition="Exists('appsettings.json')">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/DiscordHealBot/DiscordHealBot/DiscordHealBot.csproj
+++ b/DiscordHealBot/DiscordHealBot/DiscordHealBot.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+      <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DiscordHealBot/DiscordHealBot/JobSettings.cs
+++ b/DiscordHealBot/DiscordHealBot/JobSettings.cs
@@ -28,6 +28,17 @@
         /// </summary>
         public int AlertFloor { get; set; }
 
+        /// <summary>
+        /// Trigger the broadcast at a fixed time unit
+        /// </summary>
+        public bool FixedTime { get; set; }
+
+        /// <summary>
+        /// Unit of time (string ) which configures FixedTime
+        /// </summary>
+        public string TimeUnit { get; set; }
+
+
         public int GetAnnouncementTimeIntervalInMs()
         {
             return TimeInterval * 1000;

--- a/DiscordHealBot/DiscordHealBot/JobSettings.cs
+++ b/DiscordHealBot/DiscordHealBot/JobSettings.cs
@@ -38,7 +38,15 @@
         /// </summary>
         public string TimeUnit { get; set; }
 
+        /// <summary>
+        /// allowed data redis storage 
+        /// </summary>
+        public bool StoreData { get; set; }
 
+        /// <summary>
+        /// Connection string to redis server
+        /// </summary>
+        public string ConnectionStrings { get; set; }
         public int GetAnnouncementTimeIntervalInMs()
         {
             return TimeInterval * 1000;

--- a/DiscordHealBot/DiscordHealBot/JobSettings.cs
+++ b/DiscordHealBot/DiscordHealBot/JobSettings.cs
@@ -18,6 +18,16 @@
         /// </summary>
         public bool FamilyReporting { get; set; }
 
+        /// <summary>
+        /// Immedialty send an alert with (@here) tag when an endpoint latency is higher than <see cref="AlertFloor"/>
+        /// </summary>
+        public bool SendAlert { get; set; }
+        
+        /// <summary>
+        /// Alert latency in milliseconds
+        /// </summary>
+        public int AlertFloor { get; set; }
+
         public int GetAnnouncementTimeIntervalInMs()
         {
             return TimeInterval * 1000;

--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ Create an appsettings.json. This file should be located in the same folder as yo
 ## appsettings.json example
 ```json
 {
-	"ConnectionStrings": "",
     "JobSettings": {
         "TimeInterval": 30,
         "PollingInterval": 10,
         "FamilyReporting": true,
         "SendAlert": true,
         "AlertFloor": 10000,
-		"FixedTime": true,
-		"TimeUnit" :  "hour",
+	"FixedTime": true,
+	"TimeUnit" :  "hour",
+	"ConnectionStrings": "myredisserver.com, password=xxx",
+	"StoreData" : false
     },
     "EndPoints": [
           {

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Create an appsettings.json. This file should be located in the same folder as yo
 ## appsettings.json example
 ```json
 {
-
+	"ConnectionStrings": "",
     "JobSettings": {
         "TimeInterval": 30,
         "PollingInterval": 10,
         "FamilyReporting": true,
         "SendAlert": true,
-        "AlertFloor": 10000
+        "AlertFloor": 10000,
+		"FixedTime": true,
+		"TimeUnit" :  "hour",
     },
     "EndPoints": [
           {
@@ -36,6 +38,8 @@ Create an appsettings.json. This file should be located in the same folder as yo
 
 ## configuration variables
 
+`ConnectionStrings` : database connection string to ensure data continuity in case of random crash
+
 `FamilyReporting` : if true, broadcast average latency per family instead of per endpoint reporting
 
 `TimeInterval` : Time (in seconds) between two discord annoucement
@@ -49,6 +53,10 @@ Create an appsettings.json. This file should be located in the same folder as yo
 `SendAlert`: Immedialty send an alert when an endpoint is laggy
 
 `AlertFloor` : Time in milliseconds that trigger `SendAlert`
+
+`FixedTime` : Trigger the broadcast at a fixed time unit, it cancels TimeInterval
+
+`TimeUnit` : Unit of time (string ) which configures FixedTime: "day", "hour", "minute"
 
 # Docker Instructions 
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Create an appsettings.json. This file should be located in the same folder as yo
 
 ## configuration variables
 
-`ConnectionStrings` : database connection string to ensure data continuity in case of random crash
-
 `FamilyReporting` : if true, broadcast average latency per family instead of per endpoint reporting
 
 `TimeInterval` : Time (in seconds) between two discord annoucement
@@ -57,6 +55,10 @@ Create an appsettings.json. This file should be located in the same folder as yo
 `FixedTime` : Trigger the broadcast at a fixed time unit, it cancels TimeInterval
 
 `TimeUnit` : Unit of time (string ) which configures FixedTime: "day", "hour", "minute"
+
+`StoreData` : allowed application to store data using Redis to ensure data continuity in case of random crash
+
+`ConnectionStrings` : connection strings to Redis Server
 
 # Docker Instructions 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Create an appsettings.json. This file should be located in the same folder as yo
     "JobSettings": {
         "TimeInterval": 30,
         "PollingInterval": 10,
-        "FamilyReporting": true
+        "FamilyReporting": true,
+        "SendAlert": true,
+        "AlertFloor": 10000
     },
     "EndPoints": [
           {
@@ -43,6 +45,10 @@ Create an appsettings.json. This file should be located in the same folder as yo
 `EndPoints` : Endpoints to check
 
 `DiscordWebHook` : Discord Web Hook Url
+
+`SendAlert`: Immedialty send an alert when an endpoint is laggy
+
+`AlertFloor` : Time in milliseconds that trigger `SendAlert`
 
 # Docker Instructions 
 


### PR DESCRIPTION
Hello, 
Just a little improvement which allowed to set up a fixed time of broadcasting using a defined unit (day, hour, minute) and a possiblity to store datas in Redis in order to calculate a better average in case of application crash and restart.
Everything is optionnal in the Jobsettings object.
Thank you
