### PR TITLE
Update send alert

### DIFF
--- a/DiscordHealBot/DiscordHealBot/BroadCaster.cs
+++ b/DiscordHealBot/DiscordHealBot/BroadCaster.cs
@@ -61,11 +61,13 @@ namespace DiscordHealBot
  
         }
 
-        public static async Task BroadcastAlertAsync(List<EndPointHealthResult> epResults, string discordWebhook, ILogger logger)
+        public static async Task<bool> BroadcastAlertAsync(List<EndPointHealthResult> epResults, string discordWebhook, ILogger logger)
         {
-
             bool errorDiscordClient = false;
             DiscordWebhookClient client = null;
+            Color embedColor = Color.Red;
+            EmbedBuilder builder = new EmbedBuilder();
+
             try
             {
                 client = new DiscordWebhookClient(discordWebhook);
@@ -75,21 +77,23 @@ namespace DiscordHealBot
                 logger.LogInformation(e.Message);
                 errorDiscordClient = true;
             }
-            Color embedColor = Color.Red;
-            EmbedBuilder builder = new EmbedBuilder();
+
             var description = epResults.Select(x =>
             {
                 return $"⚠ : {x.EndpointAddress} responds with code {x.StatusCode} in {x.Latency}ms @here";
             }).ToList();
+
             var b = builder.WithTitle("Latency Alert")
                 .WithDescription(string.Join('\n', description))
                 .WithColor(embedColor)
                 .Build();
+
             List<Embed> embeds = new List<Embed>() { b };
+
             if (!errorDiscordClient)
                 await client.SendMessageAsync(embeds: embeds, username: "Latency Bot");
-            
-            
+
+            return !errorDiscordClient;
         }
 
         private static Color DecideEmbedColorClassic(List<EndPointHealthResult> epResults)
@@ -176,8 +180,6 @@ namespace DiscordHealBot
             return b;
         }
 
-
-
         private static string ToClassicDescription(List<EndPointHealthResult> epResults)
         {
             var str = epResults.Select(x =>
@@ -187,7 +189,6 @@ namespace DiscordHealBot
 
             return string.Join('\n', str);
         }
-
 
     }
 }

--- a/DiscordHealBot/DiscordHealBot/EndPointHealthResult.cs
+++ b/DiscordHealBot/DiscordHealBot/EndPointHealthResult.cs
@@ -10,5 +10,6 @@ namespace DiscordHealBot
         public int StatusCode { get; set; }
         public string Family { get; set; }
         public DateTime DateRun { get; set; }
+        public bool AlertSent { get; set; }
     }
 }

--- a/DiscordHealBot/DiscordHealBot/EndPointHealthResult.cs
+++ b/DiscordHealBot/DiscordHealBot/EndPointHealthResult.cs
@@ -10,6 +10,5 @@ namespace DiscordHealBot
         public int StatusCode { get; set; }
         public string Family { get; set; }
         public DateTime DateRun { get; set; }
-        public bool AlertSent { get; set; }
     }
 }


### PR DESCRIPTION
Hello,

We suggest you a fix on SendAlert method to not sending alerts that have already been processed.
The alerts were sent for each polling without distinction between those which were already processed and those which were not.
We have added an AlertSent property to define whether an alert has already been issued for an EndpointResult and not sending this alert again.

We are available if you have any questions and sorry for my English :)